### PR TITLE
Feature/#10/oauth kakao login

### DIFF
--- a/src/main/java/com/ppiyong/backend/global/security/controller/KakaoLoginController.java
+++ b/src/main/java/com/ppiyong/backend/global/security/controller/KakaoLoginController.java
@@ -20,14 +20,14 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "카카오 로그인 API Controller", description = "카카오 로그인 API")
 public class KakaoLoginController {
 
-    private final KakaoLoginServiceImpl kakaoLoginServiceImpl;
+    private final KakaoLoginServiceImpl kakaoLoginService;
 
     @Operation(summary = "카카오 인가 코드 받기", description = """
             카카오 인가 코드를 받기 위한 url을 반환합니다.
             """)
     @GetMapping("/url/kakao")
     public String get() {
-        return kakaoLoginServiceImpl.getLoginUrl();
+        return kakaoLoginService.getLoginUrl();
     }
 
     @Operation(summary = "카카오 로그인", description = """
@@ -61,7 +61,7 @@ public class KakaoLoginController {
             @RequestParam String code,
             HttpServletResponse response
     ) throws CustomException {
-        return kakaoLoginServiceImpl.login(code, response);
+        return kakaoLoginService.login(code, response);
 
     }
 }

--- a/src/main/java/com/ppiyong/backend/global/security/controller/KakaoLoginController.java
+++ b/src/main/java/com/ppiyong/backend/global/security/controller/KakaoLoginController.java
@@ -5,6 +5,10 @@ import com.ppiyong.backend.global.security.dto.response.LoginResponseDto;
 import com.ppiyong.backend.global.security.service.KakaoLoginServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +36,25 @@ public class KakaoLoginController {
             로그인 성공시 토큰을 발급합니다.
             구체적인 회원정보는 마이페이지 수정에서 처리합니다.
             """, parameters = @Parameter(name = "Code", description = "카카오로부터 받은 인가 코드"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "401", description = "카카오 토큰 받기 실패",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                {
+                  "code": "TE004",
+                  "error": "INVALID_KAKAO_ACCESS_TOKEN",
+                  "message": "카카오 토큰이 유효하지 않습니다."
+                }
+            """))),
+            @ApiResponse(responseCode = "401", description = "카카오로부터 정보 얻기 실패",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                {
+                  "code": "TE009",
+                  "error": "FAILED_KAKAO_REQUEST",
+                  "message": "카카오로부터 요청에 실패하였습니다."
+                }
+            """)))})
     @PostMapping("/login/kakao")
     public LoginResponseDto callback(
             @Parameter(description = "카카오로부터 얻은 인가 코드")

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,4 +25,4 @@ spring:
   security:
     kakao:
       client-id: ${KAKAO_REST_API_KEY}
-      redirect-uri: ${KAKAO_CALLBACK}
+      redirect-uri: ${DEV_KAKAO_CALLBACK}


### PR DESCRIPTION
## #️⃣연관된 이슈

#10 

  
## 🔎 작업 내용
- KakaoUtil을 통한 카카오 서버 인증코드 가져오기, 프로필 정보 가져오기 클래스 따로 생성
- WebClient를 이용한 KakaoServer에 수동 로그인 요청 ( 의존성 WebFlux 추가)
- 배포 환경에서의 redirect-uri 프론트에서 사용하는 uri로 수정
- OAuth2.0 추가가 아닌 WebClient로 수동 로그인 형식으로 처리 + jwt 발급 형식으로 진행

## 📷 사진 첨부
![image](https://github.com/user-attachments/assets/0099b3c0-cc3a-4d65-9606-f193d1ae6cdc)
- application.yml에 값을 따로 저장
- KakaoUtil에 WebClient 기반 서버 요청 등 구현
- KakaoLoginService에 jwt 발급 등 서비스에 맞는 로직 별도로 작성 (토큰 관리 별도)